### PR TITLE
Removed @mozvr for aframe-core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Boilerplate for using A-Frame (VR) with React.",
   "dependencies": {
-    "@mozvr/aframe-core": "0.1.0",
+    "aframe-core": "0.1.0",
     "aframe-react": "^1.0.0",
     "babel-polyfill": "^6.3.14",
     "react": "^0.14.3",

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,4 +1,4 @@
-import '@mozvr/aframe-core';
+import 'aframe-core';
 import 'babel-polyfill';
 import {Animation, Entity, Scene} from 'aframe-react';
 import React from 'react';


### PR DESCRIPTION
Just a quick change to get the boilerplate going.
Maybe @mozvr should be changed to @aframevr or ngokevin but it doesn't look like it's needed now with aframe-core being in npm.
