### PR TITLE
Updated NPM and Webpack configuration to overcome installation errors

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+	"plugins": ["syntax-jsx"],
+  "presets": ["es2015", "react", "babel-preset-stage-0"]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "aframe-bmfont-text-component": "^0.1.4",
     "aframe-react": "^3.4.0",
     "aframe-text-component": "^0.3.0",
-    "babel-polyfill": "^6.3.14"
+    "graceful-fs": "^4.1.10",
+    "lodash": "^4.16.5",
+    "minimatch": "^3.0.3",
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2"
   },
   "scripts": {
     "build": "webpack",
@@ -37,16 +41,18 @@
   "homepage": "https://github.com/ngokevin/aframe-react-boilerplate#readme",
   "devDependencies": {
     "babel": "^6.3.13",
-    "babel-core": "^6.3.15",
-    "babel-loader": "^6.2.0",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-preset-react": "^6.3.13",
-    "babel-preset-stage-0": "^6.3.13",
+    "babel-core": "^6.18.2",
+    "babel-loader": "^6.2.7",
+    "babel-plugin-syntax-jsx": "^6.18.0",
+    "babel-polyfill": "^6.16.0",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-0": "^6.16.0",
     "babel-runtime": "^6.3.13",
     "css-loader": "^0.23.0",
     "json-loader": "^0.5.4",
     "style-loader": "^0.13.0",
-    "webpack": "^1.12.9",
+    "webpack": "^1.13.3",
     "webpack-dev-server": "^1.14.0"
   }
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -27,9 +27,7 @@ class VRScene extends React.Component {
     return (
       <Scene>
         <Camera>
-          <a-cursor
-            animation__click="property: scale; startEvents: click; from: 0.1 0.1 0.1; to: 1 1 1; dur: 150"
->
+          <a-cursor animation__click="property: scale; startEvents: click; from: 0.1 0.1 0.1; to: 1 1 1; dur: 150">
           </a-cursor>
         </Camera>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,13 +4,13 @@ require('babel-polyfill');
 
 var IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
-var ENTRY_POINTS = [
-  './src/js/app'
-];
+var BUILD_DIR = path.resolve(__dirname, 'build');
 
-var JS_LOADERS = [
-  'babel?cacheDirectory&presets[]=react,presets[]=es2015,presets[]=stage-0'
-];
+var APP_DIR = path.resolve(__dirname, 'src/js');
+
+// var JS_LOADERS = [
+//   'babel?cacheDirectory&presets[]=react,presets[]=es2015,presets[]=stage-0'
+// ];
 
 var PLUGINS = [];
 if (IS_PRODUCTION) {
@@ -26,12 +26,12 @@ if (IS_PRODUCTION) {
 }
 
 module.exports = {
-  entry: ENTRY_POINTS,
+  entry: APP_DIR + '/app.js',
   output: {
     // Bundle will be served at /bundle.js locally.
     filename: 'bundle.js',
-    // Bundle will be built at ./src/media/js.
-    path: './build',
+    // Bundle will be built at ./build.
+    path: BUILD_DIR,
     publicPath: '/',
   },
   module: {
@@ -42,7 +42,9 @@ module.exports = {
       {
         // JS.
         exclude: /(node_modules|bower_components)/,
-        loaders: JS_LOADERS,
+        // loaders: JS_LOADERS,
+        include: APP_DIR,
+        loader: 'babel-loader',
         test: /\.js$/,
       },
       {
@@ -57,7 +59,7 @@ module.exports = {
   },
   plugins: PLUGINS,
   resolve: {
-    extensions: ['', '.js', '.json'],
+    extensions: ['', '.js', '.jsx', '.json'],
     fallback: path.join(__dirname, 'node_modules'),
     modulesDirectories: [
       'src/js',
@@ -65,6 +67,7 @@ module.exports = {
     ]
   },
   resolveLoader: {
+    root: path.join(__dirname, 'node_modules'),
     fallback: [path.join(__dirname, 'node_modules')]
   }
 };


### PR DESCRIPTION
Updated NPM dependencies and Webpack config to so can just run `npm install` without encountering installation errors that I encountered such as the following:
```
$ npm install
npm WARN aframe-react@3.4.0 requires a peer of react@* but none was installed.
npm WARN aframe-react@3.4.0 requires a peer of react-dom@* but none was installed.

$ npm run serve
sh: webpack-dev-server: command not found

$ npm install -g webpack-dev-server
npm WARN webpack-dev-server@1.16.2 requires a peer of webpack@>=1.3.0 <3 but none was installed.
npm WARN webpack-dev-middleware@1.8.4 requires a peer of webpack@1 || ^2.1.0-beta but none was installed.
...
Error: Cannot find module 'webpack'
Error: Cannot find module 'babel-polyfill'
``` 

```
ERROR in multi main
Module not found: Error: Cannot resolve module 'babel' 
...
ERROR in ./src/js/app.js
Module not found: Error: Cannot resolve module 'aframe'
...
```