### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "bugs": {
     "url": "https://github.com/ngokevin/aframe-react-boilerplate/issues"
   },
-  "homepage": "https://github.com/ngokevin/aframe-react-boilerplate#readme",
   "devDependencies": {
     "gh-pages": "^0.12.0"
   }


### PR DESCRIPTION
Out of the box, the build process generates paths that are not usable.
Removing the "homepage" attribute from the package.json resolved the issue.

### in index HTML:
**Before**
https://localhost:8080/ngokevin/aframe-react-boilerplate/static/1234.js

**After**
https://localhost:8080/static/1234.js

